### PR TITLE
Fixed https certification issue

### DIFF
--- a/SleeperDashboard/Program.cs
+++ b/SleeperDashboard/Program.cs
@@ -11,6 +11,16 @@ using SleeperDashboard.Client.Sleeper;
 
 var builder = WebApplication.CreateBuilder(args);
 
+var certPassword = Environment.GetEnvironmentVariable("HTTPS_CERT_PASSWORD");
+builder.WebHost.ConfigureKestrel(options =>
+{
+    options.ListenAnyIP(8080); // HTTP
+    options.ListenAnyIP(8081, listenOptions =>
+    {
+        listenOptions.UseHttps("/https/aspnetapp.pfx", certPassword);
+    });
+});
+
 // Add services to the container.
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,9 @@ services:
         ASPNETCORE_ENVIRONMENT: Development
         ASPNETCORE_URLS: "http://0.0.0.0:8080;https://0.0.0.0:8081"
         ConnectionStrings__SleeperDb: "Server=mysql;Database=SleeperDb;User=root;Password=L0caldev;"
+        HTTPS_CERT_PASSWORD: L0caldev
+    volumes:
+      - ${USERPROFILE}\.aspnet\https:/https:ro
     command: ["dotnet", "SleeperDashboard.dll"]
     
 volumes:


### PR DESCRIPTION
Updated it so it can find the cert and mount it to docker for https to work.

Open CMD and run the following:
dotnet dev-certs https -ep %USERPROFILE%\.aspnet\https\aspnetapp.pfx -p L0caldev
dotnet dev-certs https --trust

Source:
https://learn.microsoft.com/en-us/aspnet/core/security/docker-https?view=aspnetcore-9.0